### PR TITLE
Beat Saber 1.40.0 Compatibility Update

### DIFF
--- a/AmblyopiaSaber/Managers/MenuButtonManager.cs
+++ b/AmblyopiaSaber/Managers/MenuButtonManager.cs
@@ -1,5 +1,4 @@
 ﻿using AmblyopiaSaber.UI;
-using BeatSaberMarkupLanguage;
 using BeatSaberMarkupLanguage.MenuButtons;
 using HMUI;
 using System;
@@ -26,15 +25,12 @@ namespace AmblyopiaSaber.Managers
 
         public void Initialize()
         {
-            MenuButtons.instance.RegisterButton(_menuButton);
+            MenuButtons.Instance.RegisterButton(_menuButton);
         }
 
         public void Dispose()
         {
-            if (MenuButtons.IsSingletonAvailable)
-            {
-                MenuButtons.instance.UnregisterButton(_menuButton);
-            }
+            MenuButtons.Instance.UnregisterButton(_menuButton);
         }
 
         private void ShowFlow()

--- a/AmblyopiaSaber/Properties/AssemblyInfo.cs
+++ b/AmblyopiaSaber/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.0")]
-[assembly: AssemblyFileVersion("1.1.0")]
+[assembly: AssemblyVersion("2.0.0")]
+[assembly: AssemblyFileVersion("2.0.0")]

--- a/AmblyopiaSaber/manifest.json
+++ b/AmblyopiaSaber/manifest.json
@@ -3,12 +3,12 @@
   "id": "AmblyopiaSaber",
   "name": "AmblyopiaSaber",
   "author": "Bobbie & Marco",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "",
-  "gameVersion": "1.27.0",
-  "dependsOn": {
-    "BSIPA": "^4.0.5",
-    "Custom Notes": "^2.0.0"
-  },
-  "features": []
+  "gameVersion": "1.40.0",
+    "dependsOn": {
+      "BeatSaberMarkupLanguage": "^1.12.2",
+      "BSIPA": "^4.1.0",
+      "CustomNotes": "^2.0.0"
+    }
 }


### PR DESCRIPTION
By pure stubbornness I've managed to make it work with Beat Saber 1.40.0

Changes:
1. Updated target framework in project's properties to .NET Framework 4.8
2. Fixed MenuButtonManager to work with updated BSML API and added BSML ^1.12.2 dependency
3. Bumped mod version from 1.1.0 to 2.0.0. Seems justified, black screen on v1.35.0 (no idea why)
4. Updated BSIPA dependency to ^4.1.0
5. Renamed "Custom Notes" to "CustomNotes" for proper plugin detection

Tested and confirmed working on Beat Saber 1.40.0 with BSIPA 4.3.5, CustomNotes 2.6.8, BeatSaberMarkupLanguage 1.12.5 (all latest by BSManager)